### PR TITLE
Correcting downsample argument in viewer.py

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -24,7 +24,7 @@ def viewer(args, pipeline_args, model_args, optimizer_args, dataset_args):
     test_data_handler = DataHandler(
         dataset_args, rays_per_batch=0, device=device
     )
-    test_data_handler.reload(split="test", downsample=8)
+    test_data_handler.reload(split="test", downsample=min(dataset_args.downsample))
 
     # Define viewer settings
     viewer_options = {


### PR DESCRIPTION
Hi,

After training `playroom` scene of `db.zip` downloaded from #9, when running `viewer.py`, the following line:
https://github.com/theialab/radfoam/blob/366e1a1b4349023b18e7867fabd6b734983f5c3c/data_loader/colmap.py#L94
reported a `FileNotFoundError` (it will search for ''images_8" but there only exists "images" and "images_2"), which seems to be related to this line:
https://github.com/theialab/radfoam/blob/366e1a1b4349023b18e7867fabd6b734983f5c3c/viewer.py#L27
which set `downsample` a static number. Just wonder if it shoule be modified by referencing:
https://github.com/theialab/radfoam/blob/366e1a1b4349023b18e7867fabd6b734983f5c3c/test.py#L31
and
https://github.com/theialab/radfoam/blob/366e1a1b4349023b18e7867fabd6b734983f5c3c/train.py#L70

Thanks for your attention.